### PR TITLE
Improve help messaging

### DIFF
--- a/plz/main.py
+++ b/plz/main.py
@@ -5,6 +5,18 @@ import argparse
 import sys
 
 
+def usage():
+    print(Fore.BLUE + "Usage:\nplz <command> [<additional arguments> ...]")
+    print(Style.RESET_ALL)
+
+
+def list_options(config):
+    options = sorted([task['id'] for task in config])
+    print('Available commands from config:')
+    for cmd in options:
+        print(' - {cmd}'.format(cmd=cmd))
+
+
 def execute_from_config(cmd, args):
     (config, cwd) = plz_config()
 
@@ -13,8 +25,13 @@ def execute_from_config(cmd, args):
             if 'cmd' in task:
                 rc = gather_and_run_commands(task['cmd'], cwd=cwd, args=args)
                 sys.exit(rc)
-    print(Fore.RED + "Could not find command with id '{}', review the available options in the config file.".format(cmd))
-    print(Style.RESET_ALL)
+    if cmd and cmd.lower() == 'help':
+        usage()
+        list_options(config)
+    else:
+        print(Fore.RED + "Could not find command with id '{}'".format(cmd))
+        print(Style.RESET_ALL)
+        list_options(config)
     sys.exit(1)
 
 
@@ -22,9 +39,16 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('cmd')
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('cmd', nargs='?', default='help')
     parser.add_argument('passthrough_args', nargs=argparse.REMAINDER)
+
+    if len(args) < 1:
+        (config, cwd) = plz_config()
+        print()
+        usage()
+        list_options(config)
+        sys.exit(1)
 
     args = parser.parse_args(args)
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,4 @@
-from plz.main import main, execute_from_config
+from plz.main import main, execute_from_config, list_options
 import pytest
 import sys
 
@@ -14,6 +14,21 @@ def test_main_with_no_argument():
     # Assert
     with pytest.raises(SystemExit):
         main([])
+
+
+@patch('sys.exit')
+@patch('plz.main.plz_config')
+@patch('plz.main.list_options')
+def test_main_with_no_argument_call_list_options(mock_list, mock_config, mock_exit):
+    # Arrange
+    mock_config.return_value = (
+        [{'id': 'testcmd', 'cmd': 'derp'}],
+        None
+    )
+    # Act
+    main([])
+    # Assert
+    mock_list.assert_called_with(mock_config.return_value[0])
 
 
 @patch.object(sys, 'argv', ['/root/path/plz', 'testcmd', 'arg1', 'arg2'])
@@ -144,3 +159,21 @@ def test_execute_from_config_with_complex_cmd(mock_plz_config, mock_gather, mock
 
     # Assert
     mock_gather.assert_called_with(['derp', 'herp'], cwd=None, args=args)
+
+
+@patch('sys.exit')
+@patch('plz.main.list_options')
+@patch('plz.main.plz_config')
+def test_execute_from_config_with_invalid_cmd_calls_list_options(mock_plz_config, mock_list, mock_exit):
+    # Arrange
+    args = ['args']
+    mock_plz_config.return_value = (
+        [{'id': 'testcmd', 'cmd': 'derp'}],
+        None
+    )
+
+    # Act
+    execute_from_config('badcmd', args)
+
+    # Assert
+    mock_list.assert_called_with(mock_plz_config.return_value[0])


### PR DESCRIPTION
Running with no argument (`plz`) now prints a more simplistic usage
explanation (not generated from ArgParse, because that automatically
generated help/usage text does not match well with the subcommand format
in use here). It also prints a list of available commands read from the
config file, instead of simply referring the user to the config file.

Overrides `plz help` to do the same as `plz`, as above.

Finally, it prints the list of available commands (but no usage help)
when an invalid command is issued.

Resolves: #6