### PR TITLE
Remove sh dependency

### DIFF
--- a/plz/config.py
+++ b/plz/config.py
@@ -1,8 +1,8 @@
 import os
+import subprocess
 import sys
 import textwrap
 
-import sh
 import yaml
 
 from .colorize import print_error
@@ -54,10 +54,13 @@ def invalid_yaml(filename):
 
 def git_root():
     try:
-        output = sh.Command("git")("rev-parse", "--show-toplevel")
+        output = subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
         return str(output).strip()
-    except sh.ErrorReturnCode_128:
-        raise NoFileException()
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 128:
+            raise NoFileException()
+        else:
+            raise e
 
 
 def load_config(filename):

--- a/plz/runner.py
+++ b/plz/runner.py
@@ -1,8 +1,7 @@
 import os
 import shlex
+import subprocess
 import textwrap
-
-import sh
 
 from .colorize import print_error
 from .colorize import print_error_dim
@@ -21,10 +20,8 @@ def run_command(command, cwd=None, args=[]):
         args = list(process_relative_glob(args, post_adjust_path=relpath))
     executable = cleaned_cmd[0]
     try:
-        if cwd != pwd:
-            os.chdir(cwd)
-        sh.Command(executable)(*(cleaned_cmd[1:] + args), _fg=True)
-    except sh.ErrorReturnCode:
+        subprocess.check_call(cleaned_cmd + args, cwd=cwd)
+    except subprocess.CalledProcessError:
         return 1
     return 0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -286,14 +286,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "5.3.1"
 
 [[package]]
-category = "main"
-description = "Python subprocess replacement"
-name = "sh"
-optional = false
-python-versions = "*"
-version = "1.12.14"
-
-[[package]]
 category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
@@ -383,7 +375,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "b6bd88fcdfde797f2d1777348bede5d4e644ac07241fb928c5ca6ae10a37a723"
+content-hash = "4a7ee34125bdac624a6ca149e105a8134b3906d3a6c658ec2c6df9b4ad62f34d"
+lock-version = "1.0"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -514,10 +507,6 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
-]
-sh = [
-    {file = "sh-1.12.14-py2.py3-none-any.whl", hash = "sha256:ae3258c5249493cebe73cb4e18253a41ed69262484bad36fdb3efcb8ad8870bb"},
-    {file = "sh-1.12.14.tar.gz", hash = "sha256:b52bf5833ed01c7b5c5fb73a7f71b3d98d48e9b9b8764236237bdc7ecae850fc"},
 ]
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plz-cmd"
-version = "0.8.1"
+version = "0.9.0"
 description = "command line app for running configurable shell commands"
 readme = "README.md"
 authors = ["Mike Brown <mike.brown@excella.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ plz = "plz.main:main"
 python = "^3.5"
 colorama = "^0.4"
 PyYAML = ">=3.0"
-sh = "^1.12"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"


### PR DESCRIPTION
It turned out the `sh` dependency causes issues with Windows, which is not supported by the `sh` library.

https://github.com/amoffat/sh/issues/155

This PR removes `sh` and replaces it with the basic subprocess standard library.