### PR TITLE
Support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ plz test
 plz setup
 ```
 
+### Environment variables
+
+Environment variables can be set for an individual command or globally for all commands.
+
+```yaml
+# env variable for an individual command
+commands:
+- id: run
+  cmd: ./manage.py runserver
+- id: test
+  cmd: ./manage.py test
+  env:
+    DJANGO_SETTINGS_MODULE: myapp.settings.test
+```
+
+```yaml
+global_env:
+  ACCESS_TOKEN: 12345
+commands:
+- id: run
+  cmd: ./manage.py runserver
+```
+
+
 ### Globbing
 
 plz supports asterisk expansion.  For example, the cmd `ls *.py` will work as expected.

--- a/plz/runner.py
+++ b/plz/runner.py
@@ -7,7 +7,7 @@ from .colorize import print_error, print_error_dim, print_info_dim
 from .glob_tools import process_absolute_glob, process_relative_glob
 
 
-def run_command(command, cwd=None, args=[]):
+def run_command(command, cwd=None, args=[], env=None):
     pwd = os.getcwd()
     if not cwd:
         cwd = pwd
@@ -17,13 +17,13 @@ def run_command(command, cwd=None, args=[]):
         args = list(process_relative_glob(args, post_adjust_path=relpath))
     executable = cleaned_cmd[0]
     try:
-        subprocess.check_call(cleaned_cmd + args, cwd=cwd)
+        subprocess.check_call(cleaned_cmd + args, cwd=cwd, env=env)
     except subprocess.CalledProcessError:
         return 1
     return 0
 
 
-def gather_and_run_commands(cmd, cwd=None, args=[]):
+def gather_and_run_commands(cmd, cwd=None, args=[], env=None):
     """
     The cmd argument can either be a string or list
 
@@ -42,7 +42,7 @@ def gather_and_run_commands(cmd, cwd=None, args=[]):
                 )
             )
         )
-        rc = run_command(cmd, cwd=cwd, args=args)
+        rc = run_command(cmd, cwd=cwd, args=args, env=env)
         print()
         if rc > 0:
             print_error("Process failed", prefix=True)
@@ -64,7 +64,7 @@ def gather_and_run_commands(cmd, cwd=None, args=[]):
                     )
                 )
             else:
-                rc = gather_and_run_commands(item, cwd=cwd, args=args)
+                rc = gather_and_run_commands(item, cwd=cwd, args=args, env=env)
     else:
         raise Exception("Unrecognized cmd type: {}".format(type(cmd)))
     return rc

--- a/plz/schema.py
+++ b/plz/schema.py
@@ -1,15 +1,34 @@
-from jsonschema import validate
+import re
+
+from jsonschema import FormatChecker, exceptions, validate
+
+single_word_regex = "^[A-Za-z0-9_-]+$"
+
+env_variable_dict = {
+    "type": "object",
+    "patternProperties": {single_word_regex: {"type": "string"}},
+    "additionalProperties": False,
+}
+
+plz_format_checker = FormatChecker()
+
+
+@plz_format_checker.checks("single_word", TypeError)
+def is_single_word(instance):
+    return type(instance) == str and re.match(single_word_regex, instance)
+
 
 command_schema = {
     "type": "object",
     "properties": {
-        "id": {"type": "string"},  # todo: single_word_string
+        "id": {"type": "string", "format": "single_word"},  # todo: single_word_string
         "cmd": {
             "anyOf": [
                 {"type": "string"},
                 {"type": "array", "items": {"type": "string"}},
             ]
         },
+        "env": env_variable_dict,
     },
     "required": ["id", "cmd"],
 }
@@ -20,10 +39,19 @@ schema = {
         "commands": {
             "type": "array",
             "items": command_schema,
-        }
+        },
+        "global_env": env_variable_dict,
     },
 }
 
 
 def validate_configuration_data(parsed_data):
-    validate(parsed_data, schema)
+    try:
+        validate(parsed_data, schema, format_checker=plz_format_checker)
+    except TypeError as e:
+        integer_message = "expected string or bytes-like object"
+        if str(e) == integer_message:
+            raise exceptions.ValidationError(
+                f"Parsing exception: '{integer_message}'. Confirm all integer values in the .plz.yaml config are wrapped in quotes."
+            )
+        raise e

--- a/tests/gather_and_run_commands_test.py
+++ b/tests/gather_and_run_commands_test.py
@@ -18,7 +18,7 @@ def test_gather_and_run_string_cmd(mock_run):
     gather_and_run_commands(cmd)
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd=None, args=[])
+    mock_run.assert_called_with(cmd, cwd=None, args=[], env=None)
 
 
 @patch("plz.runner.run_command")
@@ -40,9 +40,9 @@ def test_gather_and_run_list_cmds(mock_run):
     mock_run.return_value = 0
     cmd = ["test cmd", "second cmd", "third cmd"]
     calls = [
-        call(cmd[0], cwd=None, args=[]),
-        call(cmd[1], cwd=None, args=[]),
-        call(cmd[2], cwd=None, args=[]),
+        call(cmd[0], cwd=None, args=[], env=None),
+        call(cmd[1], cwd=None, args=[], env=None),
+        call(cmd[2], cwd=None, args=[], env=None),
     ]
 
     # Act
@@ -72,7 +72,7 @@ def test_gather_and_run_string_cmd_with_cwd(mock_run):
     gather_and_run_commands(cmd, cwd="/root/path")
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd="/root/path", args=[])
+    mock_run.assert_called_with(cmd, cwd="/root/path", args=[], env=None)
 
 
 @patch("plz.runner.run_command")
@@ -86,7 +86,22 @@ def test_gather_and_run_string_cmd_with_args(mock_run):
     gather_and_run_commands(cmd, args=args)
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd=None, args=args)
+    mock_run.assert_called_with(cmd, cwd=None, args=args, env=None)
+
+
+@patch("plz.runner.run_command")
+def test_gather_and_run_string_cmd_with_env(mock_run):
+    # Arrange
+    mock_run.return_value = 0
+    cmd = "test cmd"
+    args = ["derp", "herp"]
+    env = {"foo": "bar"}
+
+    # Act
+    gather_and_run_commands(cmd, args=args, env=env)
+
+    # Assert
+    mock_run.assert_called_with(cmd, cwd=None, args=args, env=env)
 
 
 @patch("plz.runner.run_command")
@@ -95,9 +110,9 @@ def test_gather_and_run_list_cmds_with_error(mock_run):
     mock_run.return_value = 1
     cmd = ["test cmd", "second cmd", "third cmd"]
     calls = [
-        call(cmd[0], cwd=None, args=[]),
-        call(cmd[1], cwd=None, args=[]),
-        call(cmd[2], cwd=None, args=[]),
+        call(cmd[0], cwd=None, args=[], env=None),
+        call(cmd[1], cwd=None, args=[], env=None),
+        call(cmd[2], cwd=None, args=[], env=None),
     ]
 
     # Act
@@ -106,4 +121,4 @@ def test_gather_and_run_list_cmds_with_error(mock_run):
     # Assert
     assert rc == 1
     assert mock_run.call_count == 1
-    mock_run.assert_called_once_with(cmd[0], cwd=None, args=[])
+    mock_run.assert_called_once_with(cmd[0], cwd=None, args=[], env=None)

--- a/tests/run_command_test.py
+++ b/tests/run_command_test.py
@@ -68,6 +68,18 @@ def test_run_command_does_not_print_to_stdout_when_disabled(capfd):
     assert out == ""
 
 
+def test_run_command_accepts_env(capfd):
+    # Arrange
+    test_value = "this is a test"
+
+    # Act
+    run_command('bash -c "echo $FOO"', env={"FOO": test_value})
+    out, err = capfd.readouterr()
+
+    # Assert
+    assert out == f"{test_value}\n"
+
+
 def test_run_command_simple_glob(capfd):
     # Arrange
     stdout = "\n".join(["plz/__init__.py"]) + "\n"

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -58,6 +58,31 @@ def test_validate_command_without_id_fails():
     assert error_info.value.message == "'id' is a required property"
 
 
+@pytest.mark.parametrize(
+    "id,expect_pass",
+    [
+        ["foo", True],
+        ["foo1", True],
+        ["1foo", True],
+        ["foo_bar", True],
+        ["foo-bar", True],
+        ["foo bar", False],
+        [" foo", False],
+    ],
+)
+def test_validate_command_id(id, expect_pass):
+    # Arrange
+    schema = get_sample_schema()
+    schema["commands"][0]["id"] = id
+
+    # Act
+    if expect_pass:
+        validate_configuration_data(schema)
+    else:
+        with pytest.raises(ValidationError) as error_info:
+            validate_configuration_data(schema)
+
+
 def test_validate_command_without_cmd_fails():
     # Arrange
     schema = get_sample_schema()
@@ -69,3 +94,40 @@ def test_validate_command_without_cmd_fails():
 
     # Assert
     assert error_info.value.message == "'cmd' is a required property"
+
+
+@pytest.mark.parametrize(
+    "is_global",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "key,value,expect_pass",
+    [
+        ["foo", "bar", True],
+        ["foo_bar", "bar", True],
+        ["foo-bar", "bar", True],
+        ["foo bar", "bar", False],
+        ["foo", 'bash -c "echo Foo"', True],
+        ["foo", 1, False],
+        ["foo", "1", True],
+        [1, "bar", False],
+        ["1", "bar", True],
+    ],
+)
+def test_validate_env(key, value, expect_pass, is_global):
+    # Arrange
+    schema = get_sample_schema()
+    if is_global:
+        schema["global_env"] = {key: value}
+    else:
+        schema["commands"][0]["env"] = {key: value}
+
+    # Act
+    if expect_pass:
+        validate_configuration_data(schema)
+    else:
+        with pytest.raises(ValidationError) as error_info:
+            validate_configuration_data(schema)


### PR DESCRIPTION
This is a first iteration of support for environment variables, which resolves #18

- Support `env` for individual commands
- Support `global_env` to apply to all commmands