### PR TITLE
plz help <command>

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ plz test
 plz setup
 ```
 
+### Getting help
+
+List all the available commands with:
+
+```bash
+plz
+# or
+plz help
+```
+
+Print the yaml schema for any defined command with `plz help <command>`:
+
+```
+> plz help test
+[INFO] Using config: plz.yaml
+
+id: test
+cmd:
+- poetry run python -m pytest
+```
+
 ### Environment variables
 
 Environment variables can be set for an individual command or globally for all commands.
@@ -84,7 +105,6 @@ commands:
 - id: run
   cmd: ./manage.py runserver
 ```
-
 
 ### Globbing
 

--- a/plz/main.py
+++ b/plz/main.py
@@ -29,10 +29,11 @@ def compile_environment(cmd_env: Optional[dict], global_env: Optional[dict]) -> 
     else:
         return {}
 
+
 def command_detail(command):
     print()
     id = command.pop("id")
-    print(f"id: {id}")
+    print("id: {}".format(id))
     print(yaml.dump(command))
 
 

--- a/plz/main.py
+++ b/plz/main.py
@@ -3,6 +3,8 @@ import os
 import sys
 from typing import Optional
 
+import yaml
+
 from plz.colorize import print_error, print_info
 
 from .config import plz_config
@@ -27,6 +29,12 @@ def compile_environment(cmd_env: Optional[dict], global_env: Optional[dict]) -> 
     else:
         return {}
 
+def command_detail(command):
+    print()
+    id = command.pop("id")
+    print(f"id: {id}")
+    print(yaml.dump(command))
+
 
 def execute_from_config(cmd, args):
     (config, cwd) = plz_config()
@@ -48,8 +56,15 @@ def execute_from_config(cmd, args):
                 rc = gather_and_run_commands(task["cmd"], **kwargs)
                 sys.exit(rc)
     if cmd and cmd.lower() == "help":
+        if len(args) == 1:
+            for task in config["commands"]:
+                if "id" in task and task["id"] == args[0]:
+                    command_detail(task)
+                    sys.exit(0)
+
         usage()
         list_options(config)
+        sys.exit(0)
     else:
         print_error("Could not find command with id '{}'".format(cmd))
         list_options(config)

--- a/plz/schema.py
+++ b/plz/schema.py
@@ -52,6 +52,8 @@ def validate_configuration_data(parsed_data):
         integer_message = "expected string or bytes-like object"
         if str(e) == integer_message:
             raise exceptions.ValidationError(
-                f"Parsing exception: '{integer_message}'. Confirm all integer values in the .plz.yaml config are wrapped in quotes."
+                "Parsing exception: '{}'. Confirm all integer values in the .plz.yaml config are wrapped in quotes.".format(
+                    integer_message
+                )
             )
         raise e

--- a/tests/run_command_test.py
+++ b/tests/run_command_test.py
@@ -77,7 +77,7 @@ def test_run_command_accepts_env(capfd):
     out, err = capfd.readouterr()
 
     # Assert
-    assert out == f"{test_value}\n"
+    assert out == "{}\n".format(test_value)
 
 
 def test_run_command_simple_glob(capfd):


### PR DESCRIPTION
This is a rudimentary attempt at providing a help interface for individual commands. This resolves (to some extent) #20.

Given the following config:

```yaml
- id: test
  cmd:
  - poetry run python -m pytest
- id: setup
  cmd:
  - poetry install
  - poetry run pre-commit install
```

I get the following output:
```
> plz help
[INFO] Using config: plz.yaml
Usage:
plz <command> [<additional arguments> ...]
Available commands from config:
 - lint
 - publish
 - setup
 - test

> plz help test
[INFO] Using config: plz.yaml

id: test
cmd:
- poetry run python -m pytest

> plz help setup
[INFO] Using config: plz.yaml

id: setup
cmd:
- poetry install
- poetry run pre-commit install
```