### PR TITLE
Refactor plz.yaml schema

### DIFF
--- a/plz.yaml
+++ b/plz.yaml
@@ -1,24 +1,24 @@
 commands:
-- id: publish
-  cmd:
-  # Confirm we're on the master branch
-  - bash -c "git rev-parse --abbrev-ref HEAD | xargs -I {} bash -c '[ {} == master ] || (echo Please checkout master branch for publishing && exit 1)'"
-  # Confirm we're up to date with remote origin
-  - bash -c "git fetch origin; [ `git rev-list HEAD...origin/master --count` = 0 ] || (echo Please fetch latest commits from origin && exit 1)"
-  # Confirm there aren not any local, uncommitted changes
-  - bash -c "git diff-index --name-status --exit-code HEAD || (echo Please revert or PR local changes to origin && exit 1)"
-  # Confirm all tests are passing
-  - bash -c "plz test || (echo Please fix the tests and try again && exit 1)"
-  - poetry publish --build
-  # Create tag and push to remote origin
-  - bash -c "poetry version | awk '{print $2}' | xargs -I {} bash -c 'git tag -a {} -m {} && git push origin {}'"
+  publish:
+    cmd:
+    # Confirm we're on the master branch
+    - bash -c "git rev-parse --abbrev-ref HEAD | xargs -I {} bash -c '[ {} == master ] || (echo Please checkout master branch for publishing && exit 1)'"
+    # Confirm we're up to date with remote origin
+    - bash -c "git fetch origin; [ `git rev-list HEAD...origin/master --count` = 0 ] || (echo Please fetch latest commits from origin && exit 1)"
+    # Confirm there aren not any local, uncommitted changes
+    - bash -c "git diff-index --name-status --exit-code HEAD || (echo Please revert or PR local changes to origin && exit 1)"
+    # Confirm all tests are passing
+    - bash -c "plz test || (echo Please fix the tests and try again && exit 1)"
+    - poetry publish --build
+    # Create tag and push to remote origin
+    - bash -c "poetry version | awk '{print $2}' | xargs -I {} bash -c 'git tag -a {} -m {} && git push origin {}'"
 
-- id: test
-  cmd:
-  - poetry run python -m pytest
-- id: setup
-  cmd:
-  - poetry install
-  - poetry run pre-commit install
-- id: lint
-  cmd: poetry run pre-commit run --all-files
+  test:
+    cmd:
+    - poetry run python -m pytest
+  setup:
+    cmd:
+    - poetry install
+    - poetry run pre-commit install
+  lint:
+    cmd: poetry run pre-commit run --all-files

--- a/plz/colorize.py
+++ b/plz/colorize.py
@@ -2,6 +2,8 @@ from colorama import Fore, Style
 
 ERROR = Fore.RED
 ERROR_DIM = Fore.RED + Style.DIM
+WARNING = Fore.YELLOW
+WARNING_DIM = Fore.YELLOW + Style.DIM
 INFO = Fore.CYAN
 INFO_DIM = Fore.CYAN + Style.DIM
 RESET = Style.RESET_ALL
@@ -20,6 +22,16 @@ def print_error(text, prefix=False):
 def print_error_dim(text, prefix=False):
     prefix_string = "ERROR" if prefix else None
     return __print_text(text, ERROR_DIM, prefix_string)
+
+
+def print_warning(text, prefix=False):
+    prefix_string = "WARNING" if prefix else None
+    return __print_text(text, WARNING, prefix_string)
+
+
+def print_warning_dim(text, prefix=False):
+    prefix_string = "WARNING" if prefix else None
+    return __print_text(text, WARNING_DIM, prefix_string)
 
 
 def print_info(text, prefix=False):

--- a/plz/colorize.py
+++ b/plz/colorize.py
@@ -3,7 +3,6 @@ from colorama import Fore, Style
 ERROR = Fore.RED
 ERROR_DIM = Fore.RED + Style.DIM
 WARNING = Fore.YELLOW
-WARNING_DIM = Fore.YELLOW + Style.DIM
 INFO = Fore.CYAN
 INFO_DIM = Fore.CYAN + Style.DIM
 RESET = Style.RESET_ALL
@@ -27,11 +26,6 @@ def print_error_dim(text, prefix=False):
 def print_warning(text, prefix=False):
     prefix_string = "WARNING" if prefix else None
     return __print_text(text, WARNING, prefix_string)
-
-
-def print_warning_dim(text, prefix=False):
-    prefix_string = "WARNING" if prefix else None
-    return __print_text(text, WARNING_DIM, prefix_string)
 
 
 def print_info(text, prefix=False):

--- a/plz/config.py
+++ b/plz/config.py
@@ -4,8 +4,9 @@ import sys
 import textwrap
 
 import yaml
+from jsonschema.exceptions import ValidationError
 
-from .colorize import print_error, print_info
+from .colorize import print_error, print_info, print_warning
 from .schema import validate_configuration_data
 
 DOC_URL = "https://github.com/m3brown/plz"
@@ -66,7 +67,11 @@ def git_root():
 def load_config(filename):
     try:
         config = yaml.load(open(filename), Loader=yaml.SafeLoader)
-        validate_configuration_data(config)
+        try:
+            validate_configuration_data(config)
+        except ValidationError as e:
+            print_warning("\n" + str(e))
+            raise InvalidYamlException(filename)
         print_info("Using config: {}".format(filename), prefix=True)
         return config
     except yaml.YAMLError as e:
@@ -89,7 +94,7 @@ def plz_config():
         if not match:
             match = find_file(".plz.yaml")
             if match:
-                print_error(
+                print_warning(
                     "DEPRECATION WARNING: Please rename '.plz.yaml' to 'plz.yaml'"
                 )
             else:

--- a/plz/schema.py
+++ b/plz/schema.py
@@ -20,6 +20,7 @@ command_schema = {
         "env": env_variable_dict,
     },
     "required": ["cmd"],
+    "additionalProperties": False,
 }
 
 schema = {

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -142,16 +142,14 @@ def test_load_config_loads_yaml_file(mock_open):
     # Arrange
     mock_open.return_value = StringIO(
         textwrap.dedent(
-            u"""
+            """
             commands:
-            - id: run
-              cmd: echo "./manage.py runserver"
+              run:
+                cmd: echo "./manage.py runserver"
             """
         )
     )
-    expected_result = {
-        "commands": [{"id": "run", "cmd": 'echo "./manage.py runserver"'}]
-    }
+    expected_result = {"commands": {"run": {"cmd": 'echo "./manage.py runserver"'}}}
 
     # Act
     result = load_config("path")
@@ -165,10 +163,11 @@ def test_load_config_aborts_if_bad_yaml_file(mock_open):
     # Arrange
     mock_open.return_value = StringIO(
         textwrap.dedent(
-            u"""
-            - id: run
-              cmd: echo "./manage.py runserver"
-              foo
+            """
+            commands:
+              run:
+                cmd: echo "./manage.py runserver"
+                foo
             """
         )
     )

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -178,6 +178,26 @@ def test_load_config_aborts_if_bad_yaml_file(mock_open):
         load_config("path")
 
 
+@patch("{}.open".format(builtins_module))
+def test_load_config_aborts_if_file_does_not_match_schema(mock_open):
+    # Arrange
+    mock_open.return_value = StringIO(
+        textwrap.dedent(
+            """
+            commands:
+              run:
+                cmd: echo "./manage.py runserver"
+                foo: bar
+            """
+        )
+    )
+
+    # Act
+    # Assert
+    with pytest.raises(InvalidYamlException):
+        load_config("path")
+
+
 @patch("sys.exit")
 @patch("subprocess.check_output")
 def test_git_root_with_git_128_exception_raises_NoFileException(


### PR DESCRIPTION
Resolves #30

The existing YAML schema was inefficient for two reasons
- the set of commands was array based
- each command had an explicit `id` field, which is intended to be required and unique

Refactoring the schema to be dictionary/object based allows the config to be cleaner and the code to be more efficient.

Old:

```yaml
commands:
- id: test
  cmd: poetry run python -m pytest
- id: setup
  cmd:
  - poetry install
  - poetry run pre-commit install
```

New:
```yaml
commands:
  test:
    cmd: poetry run python -m pytest
  setup:
    cmd:
    - poetry install
    - poetry run pre-commit install
```