### PR TITLE
Better error messaging for deprecated schema format

### DIFF
--- a/plz/config.py
+++ b/plz/config.py
@@ -7,7 +7,7 @@ import yaml
 from jsonschema.exceptions import ValidationError
 
 from .colorize import print_error, print_info, print_warning
-from .schema import validate_configuration_data
+from .schema import DeprecatedSchemaException, validate_configuration_data
 
 DOC_URL = "https://github.com/m3brown/plz"
 
@@ -95,7 +95,11 @@ def plz_config():
             match = find_file(".plz.yaml")
             if match:
                 print_warning(
-                    "DEPRECATION WARNING: Please rename '.plz.yaml' to 'plz.yaml'"
+                    textwrap.dedent(
+                        """
+                        DEPRECATION WARNING: Please rename '.plz.yaml' to 'plz.yaml'
+                        """
+                    )
                 )
             else:
                 raise NoFileException
@@ -104,3 +108,6 @@ def plz_config():
         invalid_directory()
     except InvalidYamlException as e:
         invalid_yaml(e.filename)
+    except DeprecatedSchemaException:
+        # Error message is printed upstream
+        sys.exit(1)

--- a/plz/schema/__init__.py
+++ b/plz/schema/__init__.py
@@ -1,0 +1,49 @@
+from jsonschema import exceptions, validate
+
+from plz.colorize import print_error
+
+from .v1 import schema as v1_schema
+from .v2 import schema as v2_schema
+
+
+class DeprecatedSchemaException(Exception):
+    pass
+
+
+DEPRECATED_SCHEMA_MESSAGE = """
+Deprecated YAML schema: The schema for the plz.yaml file changed in plz-cmd==1.0.3, \
+and is not backwards compatible with previous versions. To continue using the legacy \
+schema, use plz-cmd==0.9.0.
+"""
+
+
+def deprecated_schema_message():
+    print_error(DEPRECATED_SCHEMA_MESSAGE)
+
+
+def check_integer_values(exception):
+    integer_message = "expected string or bytes-like object"
+    if str(exception) == integer_message:
+        raise exceptions.ValidationError(
+            "Parsing exception: '{}'. Confirm all integer values in the plz.yaml config are wrapped in quotes.".format(
+                integer_message
+            )
+        )
+
+
+def validate_configuration_data(parsed_data):
+    try:
+        validate(parsed_data, v2_schema)
+    except exceptions.ValidationError as e:
+        try:
+            validate(parsed_data, v1_schema)
+        except Exception:
+            # Raise the original validation exception for v2
+            raise e
+        # If validation does not raise an exception, the config is
+        # using the deprecated v1 schema.
+        deprecated_schema_message()
+        raise DeprecatedSchemaException()
+    except TypeError as e:
+        check_integer_values(e)
+        raise e

--- a/plz/schema/v1.py
+++ b/plz/schema/v1.py
@@ -1,0 +1,18 @@
+command_schema = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "cmd": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+            ]
+        },
+    },
+    "required": ["id", "cmd"],
+}
+
+schema = {
+    "type": "array",
+    "items": command_schema,
+}

--- a/plz/schema/v2.py
+++ b/plz/schema/v2.py
@@ -1,5 +1,3 @@
-from jsonschema import exceptions, validate
-
 single_word_regex = "^[A-Za-z0-9_-]+$"
 
 env_variable_dict = {
@@ -35,17 +33,3 @@ schema = {
         "additionalProperties": False,
     },
 }
-
-
-def validate_configuration_data(parsed_data):
-    try:
-        validate(parsed_data, schema)
-    except TypeError as e:
-        integer_message = "expected string or bytes-like object"
-        if str(e) == integer_message:
-            raise exceptions.ValidationError(
-                "Parsing exception: '{}'. Confirm all integer values in the plz.yaml config are wrapped in quotes.".format(
-                    integer_message
-                )
-            )
-        raise e

--- a/plz/schema/v2.py
+++ b/plz/schema/v2.py
@@ -30,6 +30,6 @@ schema = {
             "additionalProperties": False,
         },
         "global_env": env_variable_dict,
-        "additionalProperties": False,
     },
+    "additionalProperties": False,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plz-cmd"
-version = "1.0.4"
+version = "1.0.5"
 description = "command line app for running configurable shell commands"
 readme = "README.md"
 authors = ["Mike Brown <mike.brown@excella.com>"]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -6,6 +6,7 @@ from io import StringIO
 import pytest
 
 from plz.config import (
+    DeprecatedSchemaException,
     InvalidYamlException,
     NoFileException,
     git_root,
@@ -224,3 +225,24 @@ def test_git_root_with_good_rc(mock_check_output):
 
     # Assert
     assert result == "/sample/path"
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        InvalidYamlException("foo"),
+        NoFileException,
+        DeprecatedSchemaException,
+    ],
+)
+@patch("plz.config.find_file")
+@patch("sys.exit")
+def test_plz_config_exception_calls_sys_exit_1(mock_exit, mock_find_file, exception):
+    # Arrange
+    mock_find_file.side_effect = exception
+
+    # Act
+    plz_config()
+
+    # Assert
+    mock_exit.assert_called_once_with(1)

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -1,10 +1,14 @@
 import pytest
 from jsonschema.exceptions import ValidationError
 
-from plz.schema import validate_configuration_data
+from plz.schema import (
+    DEPRECATED_SCHEMA_MESSAGE,
+    DeprecatedSchemaException,
+    validate_configuration_data,
+)
 
 
-def get_sample_schema():
+def get_sample_config():
     return {
         "commands": {
             "test": {
@@ -19,10 +23,10 @@ def get_sample_schema():
 
 def test_validate_happy_path_succeeds():
     # Arrange
-    schema = get_sample_schema()
+    config = get_sample_config()
 
     # Act
-    validate_configuration_data(schema)
+    validate_configuration_data(config)
 
     # Assert
     pass  # exception was not raised
@@ -30,14 +34,14 @@ def test_validate_happy_path_succeeds():
 
 def test_validate_command_array_succeeds():
     # Arrange
-    schema = get_sample_schema()
-    schema["commands"]["test"]["cmd"] = [
+    config = get_sample_config()
+    config["commands"]["test"]["cmd"] = [
         "poetry install",
         "poetry run pre-commit install",
     ]
 
     # Act
-    validate_configuration_data(schema)
+    validate_configuration_data(config)
 
     # Assert
     pass  # exception was not raised
@@ -60,24 +64,24 @@ def test_validate_command_array_succeeds():
 )
 def test_validate_command_id(id, expect_pass):
     # Arrange
-    schema = {"commands": {id: {"cmd": "test command"}}}
+    config = {"commands": {id: {"cmd": "test command"}}}
 
     # Act
     if expect_pass:
-        validate_configuration_data(schema)
+        validate_configuration_data(config)
     else:
         with pytest.raises(ValidationError) as error_info:
-            validate_configuration_data(schema)
+            validate_configuration_data(config)
 
 
 def test_validate_command_without_cmd_fails():
     # Arrange
-    schema = get_sample_schema()
-    schema["commands"]["test"].pop("cmd")
+    config = get_sample_config()
+    config["commands"]["test"].pop("cmd")
 
     # Act
     with pytest.raises(ValidationError) as error_info:
-        validate_configuration_data(schema)
+        validate_configuration_data(config)
 
     # Assert
     assert error_info.value.message == "'cmd' is a required property"
@@ -106,15 +110,58 @@ def test_validate_command_without_cmd_fails():
 )
 def test_validate_env(key, value, expect_pass, is_global):
     # Arrange
-    schema = get_sample_schema()
+    config = get_sample_config()
     if is_global:
-        schema["global_env"] = {key: value}
+        config["global_env"] = {key: value}
     else:
-        schema["commands"]["test"]["env"] = {key: value}
+        config["commands"]["test"]["env"] = {key: value}
 
     # Act
     if expect_pass:
-        validate_configuration_data(schema)
+        validate_configuration_data(config)
     else:
         with pytest.raises(ValidationError) as error_info:
-            validate_configuration_data(schema)
+            validate_configuration_data(config)
+
+
+def test_legacy_config_raises_DeprecatedSchemaException():
+    # Arrange
+    legacy_config = [
+        {
+            "id": "test",
+            "cmd": "poetry run python -m pytest",
+        },
+        {
+            "id": "setup",
+            "cmd": "poetry install",
+        },
+    ]
+
+    # Act
+    # Assert
+    with pytest.raises(DeprecatedSchemaException):
+        validate_configuration_data(legacy_config)
+
+
+def test_legacy_config_prints_informational_message(capfd):
+    # Arrange
+    legacy_config = [
+        {
+            "id": "test",
+            "cmd": "poetry run python -m pytest",
+        },
+        {
+            "id": "setup",
+            "cmd": "poetry install",
+        },
+    ]
+
+    # Act
+    try:
+        validate_configuration_data(legacy_config)
+    except Exception:
+        pass
+    out, err = capfd.readouterr()
+
+    # Assert
+    assert DEPRECATED_SCHEMA_MESSAGE in out


### PR DESCRIPTION
For projects that have an existing .plz.yaml in the legacy format, new developers that `pip install plz-cmd` are in for a rude awakening. This PR attempts to improve the error messages to clarify what a schema validation failure means.

The following message appears if the yaml file fails validation BUT passes validation for the old (0.9.0) schema:

`Deprecated YAML schema: The schema for the plz.yaml file changed in plz-cmd==1.0.3, and is not backwards compatible with previous versions. To continue using the legacy schema, use plz-cmd==0.9.0.`

If the yaml file doesn't match either the old or the new schema, then the standard (difficult to read) validation error is printed to the user.