### PR TITLE
Backwards compatibility for legacy plz.yaml format

### DIFF
--- a/plz/schema/__init__.py
+++ b/plz/schema/__init__.py
@@ -42,8 +42,9 @@ def validate_configuration_data(parsed_data):
             raise e
         # If validation does not raise an exception, the config is
         # using the deprecated v1 schema.
-        deprecated_schema_message()
-        raise DeprecatedSchemaException()
+        # TODO: fully deprecate (raise exception) in a future version
+        # deprecated_schema_message()
+        # raise DeprecatedSchemaException()
     except TypeError as e:
         check_integer_values(e)
         raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plz-cmd"
-version = "1.0.5"
+version = "1.1.0"
 description = "command line app for running configurable shell commands"
 readme = "README.md"
 authors = ["Mike Brown <mike.brown@excella.com>"]

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -124,6 +126,7 @@ def test_validate_env(key, value, expect_pass, is_global):
             validate_configuration_data(config)
 
 
+@skip("Temporarily disabled for soft deprecation")
 def test_legacy_config_raises_DeprecatedSchemaException():
     # Arrange
     legacy_config = [
@@ -143,6 +146,7 @@ def test_legacy_config_raises_DeprecatedSchemaException():
         validate_configuration_data(legacy_config)
 
 
+@skip("Temporarily disabled for soft deprecation")
 def test_legacy_config_prints_informational_message(capfd):
     # Arrange
     legacy_config = [


### PR DESCRIPTION
I wasn't planning to support backwards compatibility, but I underestimated the impact to existing users.

Example scenario:

- Project X has a .plz.yaml file in their repo using the legacy format.
- Project X has a new teammate joining the team that runs `pip install plz-cmd`
  - The new teammate gets a deprecated schema error
  - The new teammate updates the schema to the new format
  - Now all the existing teammates get errors until they update plz

This PR removes the exception when a deprecated schema is encountered. Instead, the following warning is printed:

```
DEPRECATION WARNING: Your plz.yaml file is using a deprecated format. Please consider updating to the new format, support for the old format will be removed in the next version of plz-cmd.

For more information on plz.yaml formatting, visit https://github.com/m3brown/plz
```