### PR TITLE
add simple string/array commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,21 @@ Suppose we have the following `plz.yaml` file:
 
 ```yaml
 commands:
-  run:
-    cmd: ./manage.py runserver
+  # String command
+  run: ./manage.py runserver
+  # Array of command
   test:
-    description: run unit tests for both backend and frontend
-    cmd:
     - ./manage.py test
     - yarn test
+  # Object command, which supports string and array `cmd`
   setup:
+    description: Set up the development environment
     cmd:
     - poetry install
     - poetry run ./manage.py migrate
     - yarn install
-  ls:
-    cmd: ls
+  # ls example is referenced further down in this README
+  ls: ls
 ```
 
 The following commands would be available:
@@ -61,6 +62,7 @@ The following commands would be available:
 plz run
 plz test
 plz setup
+plz ls
 ```
 
 ### Getting help
@@ -117,8 +119,6 @@ Environment variables can be set for an individual command or globally for all c
 ```yaml
 # env variable for an individual command
 commands:
-  run:
-    cmd: ./manage.py runserver
   test:
     cmd: ./manage.py test
     env:
@@ -127,10 +127,9 @@ commands:
 
 ```yaml
 global_env:
-  ACCESS_TOKEN: 12345
+  DJANGO_SETTINGS_MODULE: myapp.settings.test
 commands:
-  run:
-    cmd: ./manage.py runserver
+  test: ./manage.py test
 ```
 
 ### Globbing

--- a/plz.yaml
+++ b/plz.yaml
@@ -1,11 +1,7 @@
 commands:
   test:
-    description: run unit tests
-    cmd:
     - poetry run python -m pytest
   setup:
-    description: set up local development
-    cmd:
     - poetry install
     - poetry run pre-commit install
   lint:

--- a/plz/main.py
+++ b/plz/main.py
@@ -40,6 +40,8 @@ def execute_from_config(cmd, args):
 
     data = config["commands"].get(cmd, None)
     if data:
+        if type(data) in [str, list]:
+            data = {"cmd": data}
         if data.get("cmd"):
             if data.get("dir"):
                 cwd = os.path.join(cwd or "", data["dir"])

--- a/plz/schema/v2.py
+++ b/plz/schema/v2.py
@@ -6,7 +6,7 @@ env_variables = {
     "additionalProperties": False,
 }
 
-command_schema = {
+command_obj_schema = {
     "type": "object",
     "properties": {
         "cmd": {
@@ -20,6 +20,14 @@ command_schema = {
     },
     "required": ["cmd"],
     "additionalProperties": False,
+}
+
+command_schema = {
+    "anyOf": [
+        command_obj_schema,
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}},
+    ]
 }
 
 schema = {

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -129,6 +129,45 @@ def test_execute_from_config_with_valid_cmd(mock_plz_config, mock_gather, mock_e
 @patch("sys.exit")
 @patch("plz.main.gather_and_run_commands")
 @patch("plz.main.plz_config")
+def test_execute_from_config_handles_string_command(
+    mock_plz_config, mock_gather, mock_exit
+):
+    # Arrange
+    args = ["args"]
+    config = get_sample_config()
+    config["commands"]["testcmd"] = "test string"
+    mock_plz_config.return_value = (config, None)
+
+    # Act
+    main.execute_from_config("testcmd", args)
+
+    # Assert
+    mock_gather.assert_called_with("test string", cwd=None, args=args)
+
+
+@patch("sys.exit")
+@patch("plz.main.gather_and_run_commands")
+@patch("plz.main.plz_config")
+def test_execute_from_config_handles_list_command(
+    mock_plz_config, mock_gather, mock_exit
+):
+    # Arrange
+    args = ["args"]
+    config = get_sample_config()
+    list_command = ["test string", "another string"]
+    config["commands"]["testcmd"] = list_command
+    mock_plz_config.return_value = (config, None)
+
+    # Act
+    main.execute_from_config("testcmd", args)
+
+    # Assert
+    mock_gather.assert_called_with(list_command, cwd=None, args=args)
+
+
+@patch("sys.exit")
+@patch("plz.main.gather_and_run_commands")
+@patch("plz.main.plz_config")
 def test_execute_from_config_with_dir(mock_plz_config, mock_gather, mock_exit):
     # Arrange
     args = ["args"]

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -20,6 +20,11 @@ def get_sample_config():
             "setup": {
                 "cmd": "poetry install",
             },
+            "simple_cmd": "echo 'test command'",
+            "simple_cmd2": [
+                "echo test command",
+                "echo test command",
+            ],
         }
     }
 
@@ -27,6 +32,30 @@ def get_sample_config():
 def test_validate_happy_path_succeeds():
     # Arrange
     config = get_sample_config()
+
+    # Act
+    validate_configuration_data(config)
+
+    # Assert
+    pass  # exception was not raised
+
+
+def test_validate_command_string_succeeds():
+    # Arrange
+    config = get_sample_config()
+    config["commands"]["test"] = "poetry install"
+
+    # Act
+    validate_configuration_data(config)
+
+    # Assert
+    pass  # exception was not raised
+
+
+def test_validate_command_simple_array_succeeds():
+    # Arrange
+    config = get_sample_config()
+    config["commands"]["test"] = ["poetry install", "poetry run pre-commit install"]
 
     # Act
     validate_configuration_data(config)


### PR DESCRIPTION
Support simpler syntax for simple string and list commands.

Existing command format expects an object, where each object has a `cmd` that is either a string or a list

```yaml
commands:
  foo:
    cmd: echo "bar"
  derp:
    cmd:
      - ls
      - echo "herp"
```

The new syntax supports the old format, but also supports commands that are simple strings or lists:

```yaml
commands:
  foo: echo "bar"
  derp:
    - ls
    - echo "herp"
```

The old `cmd` format remains, it's necessary if the config needs to define additional fields (description, env, etc.)