### PR TITLE
add shortcuts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ commands:
   test: ./manage.py test
 ```
 
+### Shortcuts
+
+Similar to environment variables, shortcuts can be created witin the plz.yaml
+file for reference by individual commands.
+
+```yaml
+shortcuts:
+  dc: docker-compose
+  commands:
+    start:
+      cmd: ${dc} up
+    shell:
+      cmd: ${dc} run web bash
+```
+
 ### Globbing
 
 plz supports asterisk expansion.  For example, the cmd `ls *.py` will work as expected.

--- a/plz/main.py
+++ b/plz/main.py
@@ -48,6 +48,7 @@ def execute_from_config(cmd, args):
             kwargs = {
                 "cwd": cwd,
                 "args": args,
+                "shortcuts": config.get("shortcuts", {}),
             }
             env = compile_environment(
                 data.get("env", {}), global_env=config.get("global_env", {})

--- a/plz/schema/v2.py
+++ b/plz/schema/v2.py
@@ -39,6 +39,7 @@ schema = {
             "additionalProperties": False,
         },
         "global_env": env_variables,
+        "shortcuts": env_variables,
     },
     "additionalProperties": False,
 }

--- a/tests/gather_and_run_commands_test.py
+++ b/tests/gather_and_run_commands_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from plz.runner import gather_and_run_commands
+from plz.runner import gather_and_run_commands, inject_shortcuts
 
 try:
     from mock import call, patch
@@ -18,7 +18,7 @@ def test_gather_and_run_string_cmd(mock_run):
     gather_and_run_commands(cmd)
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd=None, args=[], env=None)
+    mock_run.assert_called_with(cmd)
 
 
 @patch("plz.runner.run_command")
@@ -40,9 +40,9 @@ def test_gather_and_run_list_cmds(mock_run):
     mock_run.return_value = 0
     cmd = ["test cmd", "second cmd", "third cmd"]
     calls = [
-        call(cmd[0], cwd=None, args=[], env=None),
-        call(cmd[1], cwd=None, args=[], env=None),
-        call(cmd[2], cwd=None, args=[], env=None),
+        call(cmd[0]),
+        call(cmd[1]),
+        call(cmd[2]),
     ]
 
     # Act
@@ -72,7 +72,7 @@ def test_gather_and_run_string_cmd_with_cwd(mock_run):
     gather_and_run_commands(cmd, cwd="/root/path")
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd="/root/path", args=[], env=None)
+    mock_run.assert_called_with(cmd, cwd="/root/path")
 
 
 @patch("plz.runner.run_command")
@@ -86,7 +86,7 @@ def test_gather_and_run_string_cmd_with_args(mock_run):
     gather_and_run_commands(cmd, args=args)
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd=None, args=args, env=None)
+    mock_run.assert_called_with(cmd, args=args)
 
 
 @patch("plz.runner.run_command")
@@ -101,7 +101,7 @@ def test_gather_and_run_string_cmd_with_env(mock_run):
     gather_and_run_commands(cmd, args=args, env=env)
 
     # Assert
-    mock_run.assert_called_with(cmd, cwd=None, args=args, env=env)
+    mock_run.assert_called_with(cmd, args=args, env=env)
 
 
 @patch("plz.runner.run_command")
@@ -121,4 +121,59 @@ def test_gather_and_run_list_cmds_with_error(mock_run):
     # Assert
     assert rc == 1
     assert mock_run.call_count == 1
-    mock_run.assert_called_once_with(cmd[0], cwd=None, args=[], env=None)
+    mock_run.assert_called_once_with(cmd[0])
+
+
+@pytest.mark.parametrize(
+    "cmd,shortcuts",
+    [
+        ["echo", {}],
+        ["echo", {"foo": "bar"}],
+        [["echo", "echo"], {}],
+        [["echo", "echo"], {"foo": "bar"}],
+    ],
+)
+@patch("plz.runner.inject_shortcuts")
+def test_gather_and_run_calls_inject_shortcuts(mock_inject_shortcuts, cmd, shortcuts):
+    # Arrange
+    mock_inject_shortcuts.side_effect = lambda x, y: x
+    if shortcuts:
+        if type(cmd) == list:
+            expected_calls = [call(command, shortcuts) for command in cmd]
+        else:
+            expected_calls = [call(cmd, shortcuts)]
+    else:
+        expected_calls = []
+
+    # Act
+    gather_and_run_commands(cmd, shortcuts=shortcuts)
+
+    # Assert
+    mock_inject_shortcuts.assert_has_calls(expected_calls)
+
+
+@pytest.mark.parametrize(
+    "command,shortcuts,expected_output",
+    [
+        ["test command", {}, "test command"],
+        ["test command", {"foo": "bar"}, "test command"],
+        ["test ${foo} command", {"foo": "bar"}, "test bar command"],
+        ["test ${bar} command", {"foo": "bar"}, "test ${bar} command"],
+        ["${foo} test command", {"foo": "bar"}, "bar test command"],
+        ["test command ${foo}", {"foo": "bar"}, "test command bar"],
+        [
+            "test ${derp} command ${foo}",
+            {"foo": "bar", "derp": "herp derp"},
+            "test herp derp command bar",
+        ],
+        ['bash -c "${foo}"', {"foo": "bar"}, 'bash -c "bar"'],
+    ],
+)
+def test_run_command_calls_inject_shortcuts(command, shortcuts, expected_output):
+    # Arrange
+
+    # Act
+    result = inject_shortcuts(command, shortcuts)
+
+    # Assert
+    assert result == expected_output

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -123,7 +123,7 @@ def test_execute_from_config_with_valid_cmd(mock_plz_config, mock_gather, mock_e
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with("derp", cwd=None, args=args)
+    mock_gather.assert_called_with("derp", cwd=None, args=args, shortcuts={})
 
 
 @patch("sys.exit")
@@ -142,7 +142,7 @@ def test_execute_from_config_handles_string_command(
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with("test string", cwd=None, args=args)
+    mock_gather.assert_called_with("test string", cwd=None, args=args, shortcuts={})
 
 
 @patch("sys.exit")
@@ -162,7 +162,7 @@ def test_execute_from_config_handles_list_command(
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with(list_command, cwd=None, args=args)
+    mock_gather.assert_called_with(list_command, cwd=None, args=args, shortcuts={})
 
 
 @patch("sys.exit")
@@ -172,16 +172,13 @@ def test_execute_from_config_with_dir(mock_plz_config, mock_gather, mock_exit):
     # Arrange
     args = ["args"]
     config = get_sample_config(dir="foo")
-    mock_plz_config.return_value = (
-        config,
-        None,
-    )
+    mock_plz_config.return_value = (config, None)
 
     # Act
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with("derp", cwd="foo", args=args)
+    mock_gather.assert_called_with("derp", cwd="foo", args=args, shortcuts={})
 
 
 @patch("sys.exit")
@@ -200,7 +197,7 @@ def test_execute_from_config_with_valid_cmd_and_cwd(
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with("derp", cwd=cwd, args=args)
+    mock_gather.assert_called_with("derp", cwd=cwd, args=args, shortcuts={})
 
 
 @patch("sys.exit")
@@ -220,7 +217,9 @@ def test_execute_from_config_with_cwd_and_dir(mock_plz_config, mock_gather, mock
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with("derp", cwd="/root/path/foo", args=args)
+    mock_gather.assert_called_with(
+        "derp", cwd="/root/path/foo", args=args, shortcuts={}
+    )
 
 
 @patch("sys.exit")
@@ -240,7 +239,29 @@ def test_execute_from_config_passes_env_dict_if_defined(
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with(ANY, cwd=ANY, args=ANY, env={"foo": "bar"})
+    mock_gather.assert_called_with(
+        ANY, cwd=ANY, args=ANY, env={"foo": "bar"}, shortcuts=ANY
+    )
+
+
+@patch("sys.exit")
+@patch("plz.main.gather_and_run_commands")
+@patch("plz.main.plz_config")
+def test_execute_from_config_passes_shortcuts_dict_if_defined(
+    mock_plz_config, mock_gather, mock_exit
+):
+    # Arrange
+    args = ["args"]
+    shortcuts = {"foo": "bar"}
+    config = get_sample_config()
+    config["shortcuts"] = shortcuts
+    mock_plz_config.return_value = (config, None)
+
+    # Act
+    main.execute_from_config("testcmd", args)
+
+    # Assert
+    mock_gather.assert_called_with(ANY, cwd=ANY, args=ANY, shortcuts=shortcuts)
 
 
 @patch("sys.exit")
@@ -290,7 +311,7 @@ def test_execute_from_config_with_complex_cmd(mock_plz_config, mock_gather, mock
     main.execute_from_config("testcmd", args)
 
     # Assert
-    mock_gather.assert_called_with(["derp", "herp"], cwd=None, args=args)
+    mock_gather.assert_called_with(["derp", "herp"], cwd=None, args=args, shortcuts={})
 
 
 @patch("sys.exit")

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -120,10 +120,11 @@ def test_validate_command_without_cmd_fails():
 
 
 @pytest.mark.parametrize(
-    "is_global",
+    "config_type",
     [
-        True,
-        False,
+        "global_env",
+        "env",
+        "shortcut",
     ],
 )
 @pytest.mark.parametrize(
@@ -140,13 +141,17 @@ def test_validate_command_without_cmd_fails():
         ["1", "bar", True],
     ],
 )
-def test_validate_env(key, value, expect_pass, is_global):
+def test_validate_env(key, value, expect_pass, config_type):
     # Arrange
     config = get_sample_config()
-    if is_global:
+    if config_type == "global_env":
         config["global_env"] = {key: value}
-    else:
+    elif config_type == "env":
         config["commands"]["test"]["env"] = {key: value}
+    elif config_type == "shortcut":
+        config["shortcuts"] = {key: value}
+    else:
+        raise Exception("did not recognize config type {}".format(config_type))
 
     # Act
     if expect_pass:


### PR DESCRIPTION
Some configs have repetitive text, which a) is redundant and b) increases the odds of a typo that goes unnoticed.

Shortcuts add the ability to create a "local variable" that can be referenced elsewhere in the config. Some design decisions:
- use `${var}` as the format
- Do NOT fail if `${badvar}` is defined but does not have a match. it's possible this was intentional. For example, if the format is used downstream by the executed command.

```yaml
shortcuts:
  dc: docker-compose
  commands:
    start:
      cmd: ${dc} up
    shell:
      cmd: ${dc} run web bash
```